### PR TITLE
ci: use absolute LLVM_PROFILE_FILE path to fix 0% coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
           RUSTC_WRAPPER: ""
           RUSTFLAGS: "-Cinstrument-coverage -Zcoverage-options=branch -Ccodegen-units=1 -Copt-level=0 -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort"
           RUSTDOCFLAGS: "-Cpanic=abort"
-          LLVM_PROFILE_FILE: "grep-%p-%m.profraw"
+          LLVM_PROFILE_FILE: "${{ github.workspace }}/grep-%p-%m.profraw"
 
       - name: Install grcov
         shell: bash


### PR DESCRIPTION
The test suite spawns the grep binary inside per-test temporary directories (via uutests). With a relative LLVM_PROFILE_FILE, each subprocess wrote its .profraw into that tempdir, which gets deleted when the test ends, so the binary executing the src/ code left no coverage data and grcov reported every line as a miss (0%).

Anchoring the path to the workspace root makes the profraw files survive, raising reported coverage from 0% to ~96%.