### PR TITLE
grep: -q match yields exit 0 even after a file error

### DIFF
--- a/src/searcher.rs
+++ b/src/searcher.rs
@@ -117,7 +117,12 @@ impl<'a> Searcher<'a> {
             .flush()
             .map_err_context(|| "(standard output)".to_string())?;
 
-        if self.had_error {
+        // With -q, a match yields exit status 0 even if an error (e.g. a
+        // missing file) occurred earlier: GNU exits as soon as a line is
+        // selected, so the error never affects the status.
+        if self.config.quiet && self.any_match {
+            Ok(())
+        } else if self.had_error {
             Err(ExitCode::new(2))
         } else if self.any_match {
             Ok(())

--- a/tests/test_grep.rs
+++ b/tests/test_grep.rs
@@ -127,6 +127,28 @@ fn ere_invalid_pattern_is_error() {
 }
 
 #[test]
+fn quiet_match_overrides_file_error() {
+    // With -q, a match makes grep exit 0 even if an earlier file could not be
+    // opened. Without -q the missing file still yields exit 2, and -q with no
+    // match keeps the error status.
+    let (_s, mut c) = ucmd();
+    c.args(&["-q", "abc", "no-such-file", "-"])
+        .pipe_in("abcd\n")
+        .succeeds()
+        .no_output();
+
+    let (_s, mut c) = ucmd();
+    c.args(&["abc", "no-such-file", "-"])
+        .pipe_in("abcd\n")
+        .fails_with_code(2);
+
+    let (_s, mut c) = ucmd();
+    c.args(&["-q", "zzz", "no-such-file", "-"])
+        .pipe_in("abcd\n")
+        .fails_with_code(2);
+}
+
+#[test]
 fn fixed_string_is_literal() {
     // Metacharacters are not interpreted.
     let (_s, mut c) = ucmd();


### PR DESCRIPTION
GNU grep documents that with -q the exit status is 0 as soon as a line is selected, even if an error (such as a missing file) occurred. uu_grep let had_error take precedence, so 'grep -q PAT missing -' returned 2 instead of 0 when stdin matched. Give quiet+match priority in finish(); without -q, or with -q and no match, a file error still yields exit 2. Fixes the GNU testsuite 'status' test.