### PR TITLE
grep: reject multiple patterns with -P

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -265,6 +265,12 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     } else {
         RegexMode::Basic
     };
+    if regex_mode == RegexMode::Perl && patterns.len() > 1 {
+        return Err(USimpleError::new(
+            2,
+            "the -P option only supports a single pattern".to_string(),
+        ));
+    }
     let directory_mode = if recursive || dereference_recursive {
         DirectoryMode::Recurse
     } else {

--- a/tests/test_grep.rs
+++ b/tests/test_grep.rs
@@ -171,6 +171,23 @@ fn pcre_features() {
 }
 
 #[test]
+fn pcre_rejects_multiple_patterns() {
+    let (_s, mut c) = ucmd();
+    c.args(&["-P", "-e", "a", "-e", "b"])
+        .pipe_in("abc\n")
+        .fails_with_code(2)
+        .stderr_contains("the -P option only supports a single pattern")
+        .no_stdout();
+
+    let (_s, mut c) = ucmd();
+    c.args(&["-P", "-e", "a\nb"])
+        .pipe_in("abc\n")
+        .fails_with_code(2)
+        .stderr_contains("the -P option only supports a single pattern")
+        .no_stdout();
+}
+
+#[test]
 fn posix_character_classes() {
     let (_s, mut c) = ucmd();
     c.args(&["-E", "[[:digit:]]+"])


### PR DESCRIPTION
Fixes #34.

This rejects `-P` when normal pattern-source handling produces more than one pattern, matching the documented issue behavior for repeated `-e` and newline-split expressions. The check runs after the existing `-e`, `-f`, and positional pattern splitting, so the multi-pattern behavior for basic, extended, and fixed-string modes stays unchanged.