### PR TITLE
grep: honor GNU buffer anchors in BRE

### DIFF
--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -215,6 +215,10 @@ impl CompiledPattern {
             // GNU grep supports `{,n}` as an alias for `{0,n}`.
             syntax.enable_behavior(SyntaxBehavior::SYNTAX_BEHAVIOR_ALLOW_INTERVAL_LOW_ABBREV);
         }
+        if config.regex_mode == RegexMode::Basic {
+            // GNU grep treats \` and \' as buffer anchors.
+            syntax.enable_operators(SyntaxOperator::SYNTAX_OPERATOR_ESC_GNU_BUF_ANCHOR);
+        }
         if config.regex_mode == RegexMode::Perl {
             // GNU grep supports `(?P<name>...)`.
             // Unfortunately, the onig crate defines the OP2 flag without the

--- a/tests/test_grep.rs
+++ b/tests/test_grep.rs
@@ -70,6 +70,18 @@ fn bre_gnu_extensions() {
         .succeeds()
         .stdout_only("contain\n");
 
+    let (_s, mut c) = ucmd();
+    c.args(&[r"\`c"])
+        .pipe_in("cat\nscat\n")
+        .succeeds()
+        .stdout_only("cat\n");
+
+    let (_s, mut c) = ucmd();
+    c.args(&[r"t\'"])
+        .pipe_in("cat\ntab\n")
+        .succeeds()
+        .stdout_only("cat\n");
+
     // BRE backreference: repeated adjacent word.
     let (_s, mut c) = ucmd();
     c.args(&[r"\(\b\w\+\b\) \1"])


### PR DESCRIPTION
Fixes #33.

This enables Oniguruma's GNU buffer-anchor syntax for BRE mode so escaped backtick and escaped apostrophe are parsed as start/end anchors instead of literal characters. The change is limited to BRE because the reported mismatch is in default grep mode, and the operator is the specific Onig flag for these GNU anchor spellings.

Regression coverage adds default-mode cases for both anchors, including non-matches where the same characters appear away from the line boundary.