### PR TITLE
fix: reject multiple patterns when -P/--perl-regexp is used

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -255,6 +255,14 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         ));
     }
 
+    // GNU grep's PCRE backend (-P) supports only a single pattern.
+    if perl_regexp && patterns.len() > 1 {
+        return Err(USimpleError::new(
+            2,
+            "the -P option only supports a single pattern".to_string(),
+        ));
+    }
+
     // Decoded options into enums
     let regex_mode = if fixed_strings {
         RegexMode::Fixed

--- a/tests/test_grep.rs
+++ b/tests/test_grep.rs
@@ -171,6 +171,34 @@ fn pcre_features() {
 }
 
 #[test]
+fn perl_regexp_rejects_multiple_patterns() {
+    // GNU grep's PCRE backend (-P) only supports a single pattern.
+    // Multiple -e patterns must produce exit 2 and the canonical error message.
+    // See: https://github.com/uutils/grep/issues/34
+
+    // Two separate -e flags.
+    let (_s, mut c) = ucmd();
+    c.args(&["-P", "-e", "foo", "-e", "bar"])
+        .pipe_in("foo\nbar\n")
+        .fails_with_code(2)
+        .stderr_contains("the -P option only supports a single pattern");
+
+    // A newline inside the pattern string is split into multiple patterns.
+    let (_s, mut c) = ucmd();
+    c.args(&["-P", "-e", "foo\nbar"])
+        .pipe_in("foo\nbar\n")
+        .fails_with_code(2)
+        .stderr_contains("the -P option only supports a single pattern");
+
+    // A single pattern with -P must still work normally.
+    let (_s, mut c) = ucmd();
+    c.args(&["-P", "-e", r"\d+"])
+        .pipe_in("abc\n42\n")
+        .succeeds()
+        .stdout_only("42\n");
+}
+
+#[test]
 fn posix_character_classes() {
     let (_s, mut c) = ucmd();
     c.args(&["-E", "[[:digit:]]+"])


### PR DESCRIPTION
Closes #34

## Problem

GNU grep rejects multiple patterns when \`-P\` (PCRE mode) is used:

\`\`\`
$ grep -P -e foo -e bar file
grep: the -P option only supports a single pattern
\`\`\`

\`uu_grep\` was silently accepting multiple patterns and searching for all of them, diverging from GNU grep's behaviour.

## Fix

Added a validation check after patterns are collected (in \`src/lib.rs\`) — if \`--perl-regexp\` is set and more than one pattern was accumulated (from multiple \`-e\` flags or a newline-embedded pattern string), return exit code \`2\` with the canonical error message.

## Tests

Three cases added to \`tests/test_grep.rs::perl_regexp_rejects_multiple_patterns\`:

1. Two \`-e\` flags with \`-P\` → exit 2 + error message
2. Newline inside a single \`-e\` pattern string with \`-P\` → exit 2 + error message  
3. Single \`-e\` with \`-P\` → still works correctly

All tests pass (\`cargo test perl_regexp_rejects_multiple_patterns\`).