### PR TITLE
grep: suppress EOF output in quiet mode

### DIFF
--- a/src/searcher.rs
+++ b/src/searcher.rs
@@ -431,6 +431,9 @@ impl<'a> Searcher<'a> {
 
     /// End-of-file bookkeeping: count / `-L` / binary notice.
     fn session_finalize(&mut self, path: &Path) -> io::Result<bool> {
+        if self.config.quiet {
+            return Ok(self.session_any_match());
+        }
         if self.config.count && !self.config.files_with_matches && !self.config.files_without_match
         {
             self.writer.write_count(self.session_match_count, path)?;

--- a/tests/test_grep.rs
+++ b/tests/test_grep.rs
@@ -549,6 +549,20 @@ fn quiet_modes() {
         .pipe_in("a\n")
         .fails_with_code(1)
         .no_output();
+
+    // Quiet mode suppresses EOF bookkeeping output from -c and -L even when
+    // the no-match path reaches finalization.
+    let (_s, mut c) = ucmd();
+    c.args(&["-q", "-c", "z"])
+        .pipe_in("a\n")
+        .fails_with_code(1)
+        .no_output();
+
+    let (_s, mut c) = ucmd();
+    c.args(&["-q", "-L", "z"])
+        .pipe_in("a\n")
+        .fails_with_code(1)
+        .no_output();
 }
 
 #[test]


### PR DESCRIPTION
Fixes #22.

`-q` already suppresses output on the match path because `session_handle_match` returns early. The no-match path still reached EOF bookkeeping, so `-q -c` could print a final count and `-q -L` could print the filename.

This adds the same quiet-mode suppression at `session_finalize`, before EOF-only outputs are emitted. That keeps quiet mode responsible for exit status only, regardless of whether the search exits on a match or reaches EOF with no matches.

Covered cases:
- `grep -q -c z` with no match: exit 1, no output
- `grep -q -L z` with no match: exit 1, no output

Validated with:
- `cargo test quiet_modes -- --nocapture`
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
