### PR TITLE
grep: avoid separators for adjacent context groups

### DIFF
--- a/src/searcher.rs
+++ b/src/searcher.rs
@@ -407,21 +407,33 @@ impl<'a> Searcher<'a> {
         path: &Path,
         view: &LineView<'_>,
     ) -> io::Result<()> {
+        let last_printed_line = self.session_last_printed_line;
+        let mut context = self.session_context_buf.drain_iter().peekable();
+
+        while context
+            .peek()
+            .is_some_and(|ctx| ctx.line_number <= last_printed_line)
+        {
+            context.next();
+        }
+
+        let group_start_line = context
+            .peek()
+            .map_or(view.line_number, |ctx| ctx.line_number);
+
         // Group separator between non-adjacent groups.
         // `last_printed_line == 0` means we haven't printed anything yet.
         //   = first group = skip the separator
         if self.config.has_context
-            && self.session_last_printed_line > 0
-            && view.line_number > self.session_last_printed_line + 1
+            && last_printed_line > 0
+            && group_start_line > last_printed_line + 1
         {
             self.writer.write_group_separator()?;
         }
 
-        for ctx in self.session_context_buf.drain_iter() {
-            if ctx.line_number > self.session_last_printed_line {
-                self.writer.write_line(&ctx.view(), path)?;
-                self.session_last_printed_line = ctx.line_number;
-            }
+        for ctx in context {
+            self.writer.write_line(&ctx.view(), path)?;
+            self.session_last_printed_line = ctx.line_number;
         }
 
         self.writer.write_line(view, path)?;

--- a/tests/test_grep.rs
+++ b/tests/test_grep.rs
@@ -735,6 +735,15 @@ fn group_separator_behavior() {
 }
 
 #[test]
+fn adjacent_context_groups_do_not_get_separator() {
+    let (_s, mut c) = ucmd();
+    c.args(&["-e", ".", "-B", "2"])
+        .pipe_in("a\nb\n\n\nc\n")
+        .succeeds()
+        .stdout_only("a\nb\n\n\nc\n");
+}
+
+#[test]
 fn overlapping_context_not_duplicated() {
     let (_s, mut c) = ucmd();
     c.args(&["-n", "-C", "1", "-E", "b|d"])


### PR DESCRIPTION
Fixes #24.

When a later match pulls in before-context that starts immediately after the last printed line, the output groups are adjacent and should be merged. The old separator check compared the match line directly with the last printed line before draining before-context, so it inserted `--` even though the next emitted context line closed the gap.

This uses the first buffered context line that will actually be printed as the group start, falling back to the match line when there is no pending context.