### PR TITLE
grep: short-circuit max-count zero

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ use clap::{Arg, ArgAction, Command};
 use std::ffi::{OsStr, OsString};
 use std::io::{IsTerminal as _, Read};
 use std::path::Path;
-use uucore::error::{FromIo, UResult, USimpleError};
+use uucore::error::{ExitCode, FromIo, UResult, USimpleError};
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 #[doc(hidden)]
@@ -399,6 +399,10 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     };
 
     let matcher = Matcher::compile(&config)?;
+    if config.max_count == Some(0) {
+        return Err(ExitCode::new(1));
+    }
+
     let writer = OutputWriter::new(&config);
     let mut searcher = Searcher::new(&config, matcher, writer);
     let mut lb = LineBuffer::new(if config.null_data { b'\0' } else { b'\n' });

--- a/tests/test_grep.rs
+++ b/tests/test_grep.rs
@@ -278,6 +278,21 @@ fn max_count() {
         .fails_with_code(1)
         .no_stdout();
 
+    let (_s, mut c) = ucmd();
+    c.args(&["-m", "0", "a", "missing"])
+        .fails_with_code(1)
+        .no_output();
+
+    let (_s, mut c) = ucmd();
+    c.args(&["-m", "1", "a", "missing"])
+        .fails_with_code(2)
+        .stderr_contains("grep: missing:");
+
+    let (_s, mut c) = ucmd();
+    c.args(&["-m", "0", "-e", "["])
+        .fails_with_code(2)
+        .stderr_contains("invalid pattern");
+
     // -A trailing context still printed after the cutoff.
     let (_s, mut c) = ucmd();
     c.args(&["-m", "1", "-A", "2", "match"])


### PR DESCRIPTION
Closes #4.

`-m 0` means grep should stop before reading any input lines. In this case there can never be selected output, so after options and patterns are parsed and the matcher is compiled, the command can return the normal no-match exit before constructing the searcher or opening stdin/files.

That placement is intentional: invalid patterns still report a regex error, while missing searched files are not touched for `-m 0`. The `-m 1` path still opens inputs and reports missing-file errors as before.

I added regression coverage for the missing-file short-circuit, the `-m 1` control case, and invalid-pattern ordering.