### PR TITLE
grep: keep invalid UTF-8 text under -I

### DIFF
--- a/src/searcher.rs
+++ b/src/searcher.rs
@@ -283,7 +283,9 @@ impl<'a> Searcher<'a> {
 
             if let Some(positions) = self.session_match_line(line) {
                 // TODO: GNU grep respects LANG. Here, I'm always checking for valid UTF-8.
-                if !self.session_mark_binary_if(|| std::str::from_utf8(line).is_err()) {
+                if self.config.binary_mode != BinaryMode::WithoutMatch
+                    && !self.session_mark_binary_if(|| std::str::from_utf8(line).is_err())
+                {
                     return Ok(false);
                 }
 

--- a/tests/test_grep.rs
+++ b/tests/test_grep.rs
@@ -881,6 +881,7 @@ fn binary_files_text_forces_text_mode() {
 fn binary_files_without_match_skips() {
     let (scene, _) = ucmd();
     scene.fixtures.write_bytes("b", b"hit\0more\n");
+    scene.fixtures.write_bytes("invalid", b"a\x9db\n");
 
     let mut c = scene.cmd(env!("CARGO_BIN_EXE_grep"));
     c.args(&["-I", "hit", "b"]).fails_with_code(1).no_output();
@@ -889,6 +890,18 @@ fn binary_files_without_match_skips() {
     c.args(&["--binary-files=without-match", "hit", "b"])
         .fails_with_code(1)
         .no_output();
+
+    let mut c = scene.cmd(env!("CARGO_BIN_EXE_grep"));
+    c.args(&["-I", "a", "invalid"])
+        .succeeds()
+        .stdout_is_bytes(b"a\x9db\n")
+        .no_stderr();
+
+    let mut c = scene.cmd(env!("CARGO_BIN_EXE_grep"));
+    c.args(&["--binary-files=without-match", "a", "invalid"])
+        .succeeds()
+        .stdout_is_bytes(b"a\x9db\n")
+        .no_stderr();
 }
 
 fn build_tree(scene: &TestScenario) {


### PR DESCRIPTION
Closes #9.

`--binary-files=without-match` should suppress files once they are actually classified as binary. In this implementation NUL detection already happens before matching and still takes that path. The issue was the later invalid-UTF-8 check on matching lines: under `-I`, a matching high byte such as `\x9d` was enough to mark the session binary and return no match.

This keeps the change narrow by skipping only that invalid-UTF-8 binary classification when `binary_mode` is `WithoutMatch`. Default binary mode still reports a matching invalid-UTF-8 line as binary, and `--binary-files=text` remains unchanged. NUL bytes still make `-I` suppress output and exit with no match.

The regression coverage extends the existing `binary_files_without_match_skips` test with both `-I` and `--binary-files=without-match` invalid-UTF-8 cases, while retaining the NUL skip cases.