### PR TITLE
grep: reject multiple patterns with -P

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -265,6 +265,12 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     } else {
         RegexMode::Basic
     };
+    if regex_mode == RegexMode::Perl && patterns.len() > 1 {
+        return Err(USimpleError::new(
+            2,
+            "the -P option only supports a single pattern".to_string(),
+        ));
+    }
     let directory_mode = if recursive || dereference_recursive {
         DirectoryMode::Recurse
     } else {

--- a/tests/test_grep.rs
+++ b/tests/test_grep.rs
@@ -171,6 +171,28 @@ fn pcre_features() {
 }
 
 #[test]
+fn pcre_rejects_multiple_patterns() {
+    for args in [
+        &["-P", "-e", "a", "-e", "b"][..],
+        &["-P", "-e", "a\nb"][..],
+        &["-P", "a\nb"][..],
+    ] {
+        let (_s, mut c) = ucmd();
+        c.args(args)
+            .pipe_in("abc\n")
+            .fails_with_code(2)
+            .stderr_contains("the -P option only supports a single pattern");
+    }
+
+    let (scene, mut c) = ucmd();
+    scene.fixtures.write("pats", "a\nb\n");
+    c.args(&["-P", "-f", "pats"])
+        .pipe_in("abc\n")
+        .fails_with_code(2)
+        .stderr_contains("the -P option only supports a single pattern");
+}
+
+#[test]
 fn posix_character_classes() {
     let (_s, mut c) = ucmd();
     c.args(&["-E", "[[:digit:]]+"])


### PR DESCRIPTION
Fixes #34.

This brings `-P` closer to GNU grep for the specific PCRE restriction described in the issue: PCRE mode accepts exactly one logical pattern. Other matcher modes still keep the existing multi-pattern behavior.

The validation is placed after grep has already normalized all pattern sources into `patterns` because that is the point where the rule is easiest to express correctly. That means the same check covers:

- repeated `-e`, e.g. `-P -e a -e b`
- a single `-e` containing a newline, e.g. `-P -e 'a\nb'`
- a positional pattern containing a newline
- `-f` files with more than one pattern line

I kept this out of Clap argument validation because `-e`, `-f`, and positional patterns all flow through different input paths and only become equivalent after the existing pattern-splitting logic. Checking the normalized pattern count avoids duplicating that logic and keeps the restriction specific to `RegexMode::Perl`.

Validation:

- `printf 'abc\n' | cargo run --quiet -- -P -e a -e b` now exits `2` with `grep: the -P option only supports a single pattern`
- `cargo test pcre_rejects_multiple_patterns -- --nocapture`
- `cargo test`
- `cargo test --no-fail-fast`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --workspace -p uu_grep -- -D warnings`
- `git diff --check`
