### PR TITLE
grep: support \s and \S in BRE mode

### DIFF
--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -215,6 +215,10 @@ impl CompiledPattern {
             // GNU grep supports `{,n}` as an alias for `{0,n}`.
             syntax.enable_behavior(SyntaxBehavior::SYNTAX_BEHAVIOR_ALLOW_INTERVAL_LOW_ABBREV);
         }
+        if config.regex_mode == RegexMode::Basic {
+            // GNU grep treats `\s` and `\S` as whitespace shorthands in BRE mode.
+            syntax.enable_operators(SyntaxOperator::SYNTAX_OPERATOR_ESC_S_WHITE_SPACE);
+        }
         if config.regex_mode == RegexMode::Perl {
             // GNU grep supports `(?P<name>...)`.
             // Unfortunately, the onig crate defines the OP2 flag without the

--- a/tests/test_grep.rs
+++ b/tests/test_grep.rs
@@ -39,7 +39,7 @@ fn bre_default_metacharacters() {
 
 #[test]
 fn bre_gnu_extensions() {
-    // \+ \? \| \{m,n\} \< \> \b \w plus backreferences and leading `*`.
+    // \+ \? \| \{m,n\} \< \> \b \w \s \S plus backreferences and leading `*`.
     let (_s, mut c) = ucmd();
     c.args(&[r"o\+"])
         .pipe_in("o\noo\nx\n")
@@ -69,6 +69,18 @@ fn bre_gnu_extensions() {
         .pipe_in("contain\ncontainer\ncontained\n")
         .succeeds()
         .stdout_only("contain\n");
+
+    let (_s, mut c) = ucmd();
+    c.args(&[r"\s"])
+        .pipe_in("a b\nxy\n")
+        .succeeds()
+        .stdout_only("a b\n");
+
+    let (_s, mut c) = ucmd();
+    c.args(&["-c", r"\S"])
+        .pipe_in("aS b\n  \nx\n")
+        .succeeds()
+        .stdout_only("2\n");
 
     // BRE backreference: repeated adjacent word.
     let (_s, mut c) = ucmd();


### PR DESCRIPTION
Closes #31.

This enables Oniguruma's whitespace escape operator for `RegexMode::Basic` so GNU BRE extensions `\s` and `\S` are recognized in the default `-G` mode. The change is intentionally scoped to BRE: fixed-string mode should stay literal, ERE already uses `Syntax::gnu_regex()`, and PCRE has its own syntax path.

I chose the Onig syntax flag rather than pre-processing patterns because it keeps escaping semantics inside the regex engine and avoids hand-maintaining a second parser for these shorthands. The new test cases live in the existing `bre_gnu_extensions` coverage alongside other GNU BRE extensions.

Validation run locally:
- `cargo fmt --all -- --check`
- `cargo test bre_gnu_extensions -- --nocapture`
- `printf 'a b\nxy\n' | cargo run --quiet -- -e '\s'` -> `a b`
- `printf 'aS b\n  \nx\n' | cargo run --quiet -- -c '\S'` -> `2`
- `cargo test`
- `cargo test --no-fail-fast`
- `cargo clippy --all-targets --workspace -p uu_grep -- -D warnings`
- `git diff --check`