### PR TITLE
grep: select zero-width matches under -w and -x

### DIFF
--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -28,13 +28,10 @@ impl<'a> Matcher<'a> {
     /// Decide whether `line` matches and return the positions to highlight.
     pub fn match_line(&self, line: &[u8]) -> Option<Vec<(usize, usize)>> {
         let mut any_seen = false;
+        let mut any_selected = false;
         let positions: Vec<_> = MatchIter::new(&self.patterns, line)
             .filter(|&(start, end)| {
                 any_seen = true;
-                // Drop zero-length matches from the output.
-                if start == end {
-                    return false;
-                }
                 // Drop matches that don't span the whole line if `-x` was requested.
                 if self.config.line_regexp && !(start == 0 && end == line.len()) {
                     return false;
@@ -43,13 +40,19 @@ impl<'a> Matcher<'a> {
                 if self.config.word_regexp && !Self::is_word_match(line, start, end) {
                     return false;
                 }
+                any_selected = true;
+                // Drop zero-length matches from the output.
+                if start == end {
+                    return false;
+                }
                 true
             })
             .collect();
 
         let raw_matched = if self.config.line_regexp || self.config.word_regexp {
-            // -w / -x are authoritative once positions are filtered.
-            !positions.is_empty()
+            // -w / -x are authoritative once matches are filtered. Zero-length
+            // matches can select a line even though there is no span to output.
+            any_selected
         } else {
             any_seen
         };
@@ -174,7 +177,7 @@ struct Cursor<'a> {
 
 impl Cursor<'_> {
     fn refill(&mut self) {
-        if self.offset >= self.line.len() {
+        if self.offset > self.line.len() {
             self.pending = None;
             return;
         }

--- a/tests/test_grep.rs
+++ b/tests/test_grep.rs
@@ -251,6 +251,12 @@ fn word_regexp() {
         .pipe_in("foo bar\nfoobar\n")
         .succeeds()
         .stdout_only("foo bar\n");
+
+    let (_s, mut c) = ucmd();
+    c.args(&["-w", "$"])
+        .pipe_in("abc\n\nx\n")
+        .succeeds()
+        .stdout_only("\n");
 }
 
 #[test]
@@ -260,6 +266,12 @@ fn line_regexp() {
         .pipe_in("foo bar\nfoo bar!\nx foo bar\n")
         .succeeds()
         .stdout_only("foo bar\n");
+
+    let (_s, mut c) = ucmd();
+    c.args(&["-x", "$"])
+        .pipe_in("abc\n\nx\n")
+        .succeeds()
+        .stdout_only("\n");
 }
 
 #[test]


### PR DESCRIPTION
Closes #18.

This fixes the way `-w`/`-x` handle zero-width matches. The previous implementation used the filtered list of printable/highlight spans as the source of truth for whether a line matched under `-w` or `-x`. That loses valid zero-width matches, because they deliberately have no span to print.

The patch separates those two concepts:
- `any_selected` records whether a regex match survived `-w`/`-x` filtering.
- The returned positions still omit zero-length spans, so output/highlighting does not gain empty ranges.

There is a second necessary piece: the cursor now allows one search at EOF (`offset == line.len()`) before stopping. Without that, an empty line cannot surface the zero-width `$` match at all. The existing zero-length `start + 1` advance moves the cursor past EOF afterward, so this does not introduce an infinite loop.

Validation run locally:
- `cargo fmt --all -- --check`
- `cargo test regexp -- --nocapture`
- `printf 'abc\n\nx\n' | cargo run --quiet -- -e '$' -w | od -An -tx1` -> `0a`, exit 0
- `printf 'abc\n\nx\n' | cargo run --quiet -- -e '$' -x | od -An -tx1` -> `0a`, exit 0
- `cargo test`
- `cargo test --no-fail-fast`
- `cargo clippy --all-targets --workspace -p uu_grep -- -D warnings`
- `git diff --check`