### PR TITLE
grep: honor whitespace escapes in BRE

### DIFF
--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -273,6 +273,12 @@ impl CompiledPattern {
             // GNU grep supports \` and \' as buffer anchors in BRE and ERE.
             syntax.enable_operators(SyntaxOperator::SYNTAX_OPERATOR_ESC_GNU_BUF_ANCHOR);
         }
+        if config.regex_mode == RegexMode::Basic {
+            // GNU grep accepts \s and \S as whitespace shorthands in BRE.
+            // Follow Oniguruma's operator directly here; remaining invalid
+            // UTF-8 differences are engine semantics, not local syntax gaps.
+            syntax.enable_operators(SyntaxOperator::SYNTAX_OPERATOR_ESC_S_WHITE_SPACE);
+        }
         if config.regex_mode == RegexMode::Perl {
             // GNU grep supports `(?P<name>...)`.
             // Unfortunately, the onig crate defines the OP2 flag without the

--- a/tests/test_grep.rs
+++ b/tests/test_grep.rs
@@ -101,6 +101,27 @@ fn gnu_buffer_anchors() {
 }
 
 #[test]
+fn bre_whitespace_shorthands() {
+    let (_s, mut c) = ucmd();
+    c.args(&[r"\s"])
+        .pipe_in("a b\nxy\n")
+        .succeeds()
+        .stdout_only("a b\n");
+
+    let (_s, mut c) = ucmd();
+    c.args(&["-c", r"\S"])
+        .pipe_in("aS b\n  \nx\n")
+        .succeeds()
+        .stdout_only("2\n");
+
+    let (_s, mut c) = ucmd();
+    c.args(&[r"\s\+"])
+        .pipe_in("a  b\nxy\n")
+        .succeeds()
+        .stdout_only("a  b\n");
+}
+
+#[test]
 fn ere_metacharacters() {
     let cases: &[(&[&str], &str, &str)] = &[
         (&["-E", "Hi|HI"], "Hi\nHI\nhi\n", "Hi\nHI\n"),


### PR DESCRIPTION
Fixes #31.

GNU grep accepts `\s` and `\S` as whitespace shorthands in basic regular expressions. Extended mode already recognizes those spellings through `Syntax::gnu_regex()`, but the default BRE path treated them as literal `s`/`S` because `Syntax::grep()` does not enable that GNU extension by default.

This now enables Oniguruma's `SYNTAX_OPERATOR_ESC_S_WHITE_SPACE` for BRE. That keeps the implementation small and uses the regex engine's own syntax support instead of rewriting patterns before compilation.

One tradeoff is intentionally left in place: Oniguruma's direct `\S` behavior can differ from GNU grep on lone invalid UTF-8 bytes. I had previously worked around that by expanding `\s`/`\S` into POSIX classes, but that was a disproportionately large local workaround while other GNU/Oniguruma semantic gaps still remain. This version fixes the common valid-input shorthand behavior and BRE repetition support without adding a custom mini parser.

Validation:
- `cargo fmt --all -- --check`
- `cargo test bre_whitespace_shorthands`
- `cargo test`
- `cargo clippy --all-targets --workspace -puu_grep -- -D warnings`
- `git diff --check`
