### PR TITLE
grep: honor GNU buffer anchors

### DIFF
--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -269,6 +269,10 @@ impl CompiledPattern {
             // GNU grep supports `{,n}` as an alias for `{0,n}`.
             syntax.enable_behavior(SyntaxBehavior::SYNTAX_BEHAVIOR_ALLOW_INTERVAL_LOW_ABBREV);
         }
+        if matches!(config.regex_mode, RegexMode::Basic | RegexMode::Extended) {
+            // GNU grep supports \` and \' as buffer anchors in BRE and ERE.
+            syntax.enable_operators(SyntaxOperator::SYNTAX_OPERATOR_ESC_GNU_BUF_ANCHOR);
+        }
         if config.regex_mode == RegexMode::Perl {
             // GNU grep supports `(?P<name>...)`.
             // Unfortunately, the onig crate defines the OP2 flag without the

--- a/tests/test_grep.rs
+++ b/tests/test_grep.rs
@@ -86,6 +86,33 @@ fn bre_gnu_extensions() {
 }
 
 #[test]
+fn gnu_buffer_anchors() {
+    let (_s, mut c) = ucmd();
+    c.args(&[r"\`c"])
+        .pipe_in("cat\nscat\ndog\n")
+        .succeeds()
+        .stdout_only("cat\n");
+
+    let (_s, mut c) = ucmd();
+    c.args(&[r"t\'"])
+        .pipe_in("cat\ntar\ndog\n")
+        .succeeds()
+        .stdout_only("cat\n");
+
+    let (_s, mut c) = ucmd();
+    c.args(&["-E", r"\`c"])
+        .pipe_in("cat\nscat\ndog\n")
+        .succeeds()
+        .stdout_only("cat\n");
+
+    let (_s, mut c) = ucmd();
+    c.args(&["-E", r"t\'"])
+        .pipe_in("cat\ntar\ndog\n")
+        .succeeds()
+        .stdout_only("cat\n");
+}
+
+#[test]
 fn ere_metacharacters() {
     let cases: &[(&[&str], &str, &str)] = &[
         (&["-E", "Hi|HI"], "Hi\nHI\nhi\n", "Hi\nHI\n"),

--- a/tests/test_grep.rs
+++ b/tests/test_grep.rs
@@ -88,28 +88,16 @@ fn bre_gnu_extensions() {
 #[test]
 fn gnu_buffer_anchors() {
     let (_s, mut c) = ucmd();
-    c.args(&[r"\`c"])
-        .pipe_in("cat\nscat\ndog\n")
+    c.args(&[r"\`c\|r\'"])
+        .pipe_in("cat\nscat\ntar\ndog\n")
         .succeeds()
-        .stdout_only("cat\n");
+        .stdout_only("cat\ntar\n");
 
     let (_s, mut c) = ucmd();
-    c.args(&[r"t\'"])
-        .pipe_in("cat\ntar\ndog\n")
+    c.args(&["-E", r"\`c|r\'"])
+        .pipe_in("cat\nscat\ntar\ndog\n")
         .succeeds()
-        .stdout_only("cat\n");
-
-    let (_s, mut c) = ucmd();
-    c.args(&["-E", r"\`c"])
-        .pipe_in("cat\nscat\ndog\n")
-        .succeeds()
-        .stdout_only("cat\n");
-
-    let (_s, mut c) = ucmd();
-    c.args(&["-E", r"t\'"])
-        .pipe_in("cat\ntar\ndog\n")
-        .succeeds()
-        .stdout_only("cat\n");
+        .stdout_only("cat\ntar\n");
 }
 
 #[test]


### PR DESCRIPTION
Fixes #33.

GNU grep recognizes ``\` `` and `\'` as start/end buffer anchors in both BRE and ERE mode. In this implementation, grep searches one record/line at a time, so those GNU buffer anchors behave like the record-local start/end anchors for the cases in this issue. The current `Syntax::grep()` and `Syntax::gnu_regex()` setup did not enable Oniguruma's GNU buffer-anchor operator, so the escapes were treated as literal backtick/apostrophe characters.

This enables `SYNTAX_OPERATOR_ESC_GNU_BUF_ANCHOR` only for `RegexMode::Basic` and `RegexMode::Extended`. I left Fixed untouched because escapes are literals there, and left Perl untouched because `-P` should follow the PCRE-style syntax path rather than GNU BRE/ERE extensions.

Validation:
- `cargo fmt --all -- --check`
- `cargo test`
- `cargo clippy --all-targets --workspace -puu_grep -- -D warnings`
- `git diff --check`
- `printf 'cat\ndog\n' | cargo run --quiet -- -e "t\\'"` now prints `cat`
- `printf 'cat\ndog\n' | cargo run --quiet -- -e '\`c'` now prints `cat`
