### PR TITLE
grep: make the literal-only matcher a cargo feature instead of a WASI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,40 @@ jobs:
       - name: Run tests
         run: cargo test --verbose
 
+  wasm:
+    name: Check wasm32-wasip1 (no oniguruma)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-wasip1
+
+      # Without a C sysroot, oniguruma cannot be built for this target, so the
+      # crate is checked with the literal-only matcher. A WASI build that does
+      # have a wasi-sdk sysroot can keep the default features instead.
+      - name: Check
+        run: cargo check --target wasm32-wasip1 --no-default-features
+
+  no-oniguruma:
+    name: Build & test without oniguruma
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Build
+        run: cargo build --no-default-features --verbose
+
+      # Most of the suite exercises real regexes, which this configuration
+      # cannot serve; only the tests covering the fallback itself are run.
+      - name: Run fallback tests
+        run: cargo test --no-default-features --verbose literal_only_build
+
   coverage:
     name: Code coverage (${{ matrix.os }})
     runs-on: ${{ matrix.os }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,12 +18,20 @@ path = "src/main.rs"
 name = "uu_grep"
 path = "src/lib.rs"
 
+[features]
+default = ["oniguruma"]
+# Full regex support, backed by the oniguruma C library. Turning it off drops
+# the C dependency and leaves a matcher that handles literal patterns only,
+# which is what lets targets without a C toolchain build the crate (e.g.
+# wasm32-wasi* with no wasi-sdk sysroot available).
+oniguruma = ["dep:onig", "dep:onig_sys"]
+
 [dependencies]
 clap = { version = "4.5", features = ["wrap_help", "cargo", "color"] }
 glob = "0.3.1"
 memchr = "2.7.2"
-onig = { version = "~6.5.1", default-features = false }
-onig_sys = { version = "*", default-features = false }
+onig = { version = "~6.5.1", default-features = false, optional = true }
+onig_sys = { version = "*", default-features = false, optional = true }
 uucore = "0.10.0"
 walkdir = "2.5"
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,29 @@ cargo build --release
 cargo test
 ```
 
+### The `oniguruma` feature
+
+Regex matching is backed by [oniguruma](https://github.com/kkos/oniguruma), a C
+library built from source by `onig_sys`, so a build needs a C toolchain for the
+target. That feature is on by default and is what provides BRE, ERE and `-P`.
+
+Targets without a C toolchain can build with `--no-default-features`, which
+drops the C dependency and leaves a matcher handling literal patterns only;
+anything requiring a regex engine then exits with status 2 and an explicit
+error. This is what makes `cargo check --target wasm32-wasip1
+--no-default-features` work out of the box.
+
+It is a feature rather than a target check on purpose: a WASI build that *does*
+have a C sysroot keeps the real engine. With a
+[wasi-sdk](https://github.com/WebAssembly/wasi-sdk) installed, point the C
+toolchain at it and build with default features:
+
+```shell
+export CC_wasm32_wasip2=/opt/wasi-sdk/bin/clang
+export CFLAGS_wasm32_wasip2="--sysroot=/opt/wasi-sdk/share/wasi-sysroot"
+cargo build --target wasm32-wasip2
+```
+
 ## Pre-commit hooks
 
 This project uses [pre-commit](https://pre-commit.com); run `pre-commit install` to enable the git hooks.

--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -5,15 +5,21 @@
 
 use crate::{Config, RegexMode};
 use memchr::memmem;
+#[cfg(feature = "oniguruma")]
 use onig::{RegexOptions, Region, SearchOptions, Syntax, SyntaxBehavior, SyntaxOperator};
+#[cfg(feature = "oniguruma")]
 use onig_sys::{
     ONIGERR_EMPTY_RANGE_IN_CHAR_CLASS, OnigEncCtype_ONIGENC_CTYPE_WORD, OnigEncodingUTF8,
 };
+#[cfg(feature = "oniguruma")]
 use std::ptr::{null, null_mut};
+#[cfg(feature = "oniguruma")]
 use std::sync::Mutex;
 use uucore::error::{UResult, USimpleError};
+#[cfg(feature = "oniguruma")]
 use uucore::show_warning;
 
+#[cfg(feature = "oniguruma")]
 static ONIG_NEW_MUTEX: Mutex<()> = Mutex::new(());
 
 pub struct Matcher<'a> {
@@ -115,6 +121,7 @@ impl<'a> Matcher<'a> {
     /// Word-boundary check `-w`.
     /// NOTE that `-w` does not check both sides, unlike `\b` in a regex.
     /// Start/End-of-line count as non-words.
+    #[cfg(feature = "oniguruma")]
     fn is_word_match(line: &[u8], start: usize, end: usize) -> bool {
         // SAFETY: This code uses OnigEncodingType such that it can support other types of encodings in the future.
         unsafe {
@@ -140,6 +147,24 @@ impl<'a> Matcher<'a> {
 
             true
         }
+    }
+
+    /// Without oniguruma there is no encoding table to consult, so this is a
+    /// conservative ASCII-only boundary check for the literal patterns that the
+    /// fallback matcher accepts.
+    #[cfg(not(feature = "oniguruma"))]
+    fn is_word_match(line: &[u8], start: usize, end: usize) -> bool {
+        fn is_ascii_word(byte: u8) -> bool {
+            byte.is_ascii_alphanumeric() || byte == b'_'
+        }
+
+        if end < line.len() && is_ascii_word(line[end]) {
+            return false;
+        }
+        if start > 0 && is_ascii_word(line[start - 1]) {
+            return false;
+        }
+        true
     }
 }
 
@@ -252,6 +277,7 @@ fn plain_literal(pattern: &str, ignore_case: bool, mode: RegexMode) -> Option<Ve
     plain.then(|| pattern.as_bytes().to_vec())
 }
 
+#[cfg(feature = "oniguruma")]
 struct CompiledPattern {
     /// Default semantics. It's decently fast and used for searching.
     leftmost: OnigRegex,
@@ -261,6 +287,7 @@ struct CompiledPattern {
     longest_anchored: OnigRegex,
 }
 
+#[cfg(feature = "oniguruma")]
 impl CompiledPattern {
     fn compile(pattern: &str, config: &Config) -> UResult<Self> {
         let mut syntax = *match config.regex_mode {
@@ -363,17 +390,21 @@ impl CompiledPattern {
     }
 }
 
+#[cfg(feature = "oniguruma")]
 struct OnigRegex {
     raw: onig_sys::OnigRegex,
 }
 
 // SAFETY: Oniguruma compiled regexes are immutable after construction, and this
 // wrapper owns and frees the raw pointer exactly once. This mirrors `onig::Regex`.
+#[cfg(feature = "oniguruma")]
 unsafe impl Send for OnigRegex {}
 // SAFETY: Searches only read the compiled regex. Capture storage is caller-owned
 // through `Region`, so sharing the compiled regex across threads is safe.
+#[cfg(feature = "oniguruma")]
 unsafe impl Sync for OnigRegex {}
 
+#[cfg(feature = "oniguruma")]
 impl OnigRegex {
     fn compile(pattern: &str, syntax: &Syntax, options: RegexOptions) -> Result<Self, OnigError> {
         let pattern = pattern.as_bytes();
@@ -459,6 +490,7 @@ impl OnigRegex {
     }
 }
 
+#[cfg(feature = "oniguruma")]
 impl Drop for OnigRegex {
     fn drop(&mut self) {
         // SAFETY: `raw` was returned by a successful `onig_new_deluxe` call and
@@ -467,11 +499,13 @@ impl Drop for OnigRegex {
     }
 }
 
+#[cfg(feature = "oniguruma")]
 struct OnigError {
     code: i32,
     message: String,
 }
 
+#[cfg(feature = "oniguruma")]
 impl OnigError {
     fn new(code: i32, info: *const onig_sys::OnigErrorInfo) -> Self {
         Self {
@@ -481,12 +515,14 @@ impl OnigError {
     }
 }
 
+#[cfg(feature = "oniguruma")]
 fn region_ptr(region: Option<&mut Region>) -> *mut onig_sys::OnigRegion {
     region.map_or(null_mut(), |r| {
         r as *mut Region as *mut onig_sys::OnigRegion
     })
 }
 
+#[cfg(feature = "oniguruma")]
 fn onig_match_result(result: i32) -> Option<usize> {
     if result >= 0 {
         Some(result as usize)
@@ -500,12 +536,14 @@ fn onig_match_result(result: i32) -> Option<usize> {
     }
 }
 
+#[cfg(feature = "oniguruma")]
 fn onig_error_message(code: i32, info: *const onig_sys::OnigErrorInfo) -> String {
     let mut buff = [0; onig_sys::ONIG_MAX_ERROR_MESSAGE_LEN as usize];
     let len = unsafe { onig_sys::onig_error_code_to_str(buff.as_mut_ptr(), code, info) };
     String::from_utf8_lossy(&buff[..len as usize]).into_owned()
 }
 
+#[cfg(feature = "oniguruma")]
 fn strip_leading_repeat_operator(pattern: &str) -> Option<(&'static str, &str)> {
     match pattern.as_bytes().first()? {
         b'?' => Some(("?", &pattern[1..])),
@@ -516,6 +554,7 @@ fn strip_leading_repeat_operator(pattern: &str) -> Option<(&'static str, &str)> 
     }
 }
 
+#[cfg(feature = "oniguruma")]
 fn strip_leading_interval_repeat(pattern: &str) -> Option<&str> {
     let close = pattern.as_bytes().iter().position(|&b| b == b'}')?;
     let body = &pattern[1..close];
@@ -523,6 +562,49 @@ fn strip_leading_interval_repeat(pattern: &str) -> Option<&str> {
         && body.bytes().all(|b| b.is_ascii_digit() || b == b',')
         && body.bytes().any(|b| b.is_ascii_digit());
     is_interval.then_some(&pattern[close + 1..])
+}
+
+/// Literal-only stand-in used when the crate is built without the `oniguruma`
+/// feature, i.e. without a regex engine to compile patterns with.
+#[cfg(not(feature = "oniguruma"))]
+struct CompiledPattern {
+    needle: Vec<u8>,
+    finder: memmem::Finder<'static>,
+}
+
+#[cfg(not(feature = "oniguruma"))]
+impl CompiledPattern {
+    fn compile(pattern: &str, config: &Config) -> UResult<Self> {
+        let Some(needle) = plain_literal(pattern, config.ignore_case, config.regex_mode) else {
+            return Err(USimpleError::new(
+                2,
+                "this build supports ASCII literal patterns only; rebuild with the `oniguruma` feature for full regex support".to_string(),
+            ));
+        };
+        let finder = memmem::Finder::new(&needle).into_owned();
+        Ok(Self { needle, finder })
+    }
+
+    /// Find the leftmost match starting at or after `offset`.
+    fn search_leftmost(&self, line: &[u8], offset: usize) -> Option<(usize, usize)> {
+        self.finder.find(&line[offset..]).map(|relative| {
+            let start = offset + relative;
+            (start, start + self.needle.len())
+        })
+    }
+
+    /// Given a known leftmost start `start`, return the longest extent
+    /// of a match anchored exactly there.
+    fn longest_end_at(&self, line: &[u8], start: usize) -> Option<usize> {
+        line.get(start..start + self.needle.len())
+            .is_some_and(|bytes| bytes == self.needle.as_slice())
+            .then_some(start + self.needle.len())
+    }
+
+    /// True if any match exists in `line`.
+    fn is_match(&self, line: &[u8]) -> bool {
+        self.finder.find(line).is_some()
+    }
 }
 
 #[cfg(test)]

--- a/tests/test_grep.rs
+++ b/tests/test_grep.rs
@@ -1812,3 +1812,55 @@ fn only_matching_with_context() {
         .succeeds()
         .stdout_only("4:xx\n");
 }
+
+/// The crate can be built without the `oniguruma` feature (no C toolchain, e.g.
+/// a wasm32-wasi* target with no wasi-sdk sysroot). Such a build keeps literal
+/// searching and reports a clear error for anything needing a regex engine.
+#[cfg(not(feature = "oniguruma"))]
+#[test]
+fn literal_only_build_handles_plain_patterns() {
+    // Plain literals still match, including under -F, -w and -x. Case-insensitive
+    // search is not part of the fallback: folding needs the regex engine.
+    let (_s, mut c) = ucmd();
+    c.args(&["quartz"])
+        .pipe_in("granite\nquartz vein\nbasalt\n")
+        .succeeds()
+        .stdout_only("quartz vein\n");
+
+    let (_s, mut c) = ucmd();
+    c.args(&["-F", "3+4"])
+        .pipe_in("3+4\n34\n")
+        .succeeds()
+        .stdout_only("3+4\n");
+
+    let (_s, mut c) = ucmd();
+    c.args(&["-w", "kiwi"])
+        .pipe_in("kiwifruit\na kiwi here\n")
+        .succeeds()
+        .stdout_only("a kiwi here\n");
+
+    let (_s, mut c) = ucmd();
+    c.args(&["-x", "solo"])
+        .pipe_in("solo\nsolo act\n")
+        .succeeds()
+        .stdout_only("solo\n");
+
+    // No match keeps the usual exit code 1.
+    let (_s, mut c) = ucmd();
+    c.args(&["obsidian"])
+        .pipe_in("granite\n")
+        .fails_with_code(1)
+        .no_output();
+}
+
+#[cfg(not(feature = "oniguruma"))]
+#[test]
+fn literal_only_build_rejects_regex_patterns() {
+    for pattern in ["gr[ae]y", "we*b", "^anchored"] {
+        let (_s, mut c) = ucmd();
+        c.args(&[pattern])
+            .pipe_in("grey\n")
+            .fails_with_code(2)
+            .stderr_contains("ASCII literal patterns only");
+    }
+}


### PR DESCRIPTION
onig_sys builds oniguruma from C sources, so `cargo check --target wasm32-wasip1` fails unless the caller supplies a C WASI sysroot. Add a default-on `oniguruma` feature; `--no-default-features` drops the C dependency and falls back to a literal-only matcher that reports an explicit error for patterns needing a regex engine.

Gating on the feature rather than on `target_os = "wasi"` keeps the real engine for WASI builds that do have a sysroot: oniguruma compiles and passes the full BRE/ERE/-P suite on wasm32-wasip2 when CC_wasm32_wasip2 and CFLAGS_wasm32_wasip2 point at a wasi-sdk.

CI checks wasm32-wasip1 with --no-default-features and builds and tests the fallback natively.