### PR TITLE
grep: keep only the requested number of before-context lines

### DIFF
--- a/src/context_buffer.rs
+++ b/src/context_buffer.rs
@@ -42,13 +42,16 @@ impl BufferedLine {
 /// provide a more optimized `ContextBuffer` when `mmap()` is available.
 pub struct ContextBuffer {
     slots: Vec<BufferedLine>,
+    /// Number of lines to retain. `slots` is rounded up to a power of two so
+    /// `push` can mask instead of divide, so it may be larger than this.
+    capacity: usize,
     head: usize,
     len: usize,
 }
 
 impl ContextBuffer {
     pub fn new(capacity: usize) -> Self {
-        let len = if capacity == 0 {
+        let slots = if capacity == 0 {
             0
         } else {
             capacity.next_power_of_two()
@@ -60,8 +63,9 @@ impl ContextBuffer {
                     line_number: 0,
                     byte_offset: 0,
                 };
-                len
+                slots
             ],
+            capacity,
             head: 0,
             len: 0,
         }
@@ -90,7 +94,7 @@ impl ContextBuffer {
         slot.byte_offset = byte_offset;
 
         self.head = self.head.wrapping_add(1);
-        self.len = (self.len + 1).min(self.slots.len());
+        self.len = (self.len + 1).min(self.capacity);
     }
 
     pub fn drain_iter(&mut self) -> impl Iterator<Item = &BufferedLine> {

--- a/tests/test_grep.rs
+++ b/tests/test_grep.rs
@@ -1051,6 +1051,26 @@ fn after_before_combined_context() {
 }
 
 #[test]
+fn before_context_is_not_rounded_to_power_of_two() {
+    // The context ring buffer rounds its slot count up to a power of two, but
+    // must still retain only the requested number of lines.
+    let input = "01\n02\n03\n04\n05\n06\n07\n08\n09\n10\nMM\n";
+
+    for (n, expected) in [
+        ("3", "08\n09\n10\nMM\n"),
+        ("5", "06\n07\n08\n09\n10\nMM\n"),
+        ("6", "05\n06\n07\n08\n09\n10\nMM\n"),
+        ("7", "04\n05\n06\n07\n08\n09\n10\nMM\n"),
+    ] {
+        let (_s, mut c) = ucmd();
+        c.args(&["-e", "MM", "-B", n])
+            .pipe_in(input)
+            .succeeds()
+            .stdout_only(expected);
+    }
+}
+
+#[test]
 fn num_shorthand_is_context() {
     // `-2` is shorthand for `-C 2`.
     let (_s, mut c) = ucmd();


### PR DESCRIPTION
Fixes #66.

`ContextBuffer::new` rounds its slot count up to a power of two so `push` can mask instead of divide. `push` then capped the live length with `.min(self.slots.len())` — the *rounded* count — so the buffer retained up to the next power of two rather than the requested `-B N`. That is why `-B 1/2/4/8` looked correct while `-B 3` printed four lines.

Kept the power-of-two slot allocation (the mask in `push`/`drain_iter` depends on it) and stored the requested capacity separately to bound `len`.

```
$ printf '01\n...\n10\nMM\n' | grep -e MM -B 3
08
09
10
MM
```

Diffed `-B` and `-C` for N=1..8 against GNU grep on the issue's input: identical for every value. Added a regression test over N=3,5,6,7 — the non-power-of-two values, since the powers of two passed even with the bug.

`cargo test`: 95 passed. clippy `-D warnings` and `cargo fmt --check` clean.