### PR TITLE
grep: don't short-circuit -v empty pattern under -x/-w

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -445,8 +445,15 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     }
 
     // An empty pattern matches every line; with `-v`, GNU grep selects no lines
-    // and exits as "no match" without reading any input files.
-    if invert_match && patterns.iter().any(|pattern| pattern.is_empty()) {
+    // and exits as "no match" without reading any input files. This does not
+    // hold under `-x` or `-w`, where an empty pattern matches only an empty
+    // line or an empty match at a word boundary, so the inversion still selects
+    // the remaining lines and the input has to be read.
+    if invert_match
+        && !word_regexp
+        && !line_regexp
+        && patterns.iter().any(|pattern| pattern.is_empty())
+    {
         return Err(ExitCode::new(1));
     }
 

--- a/tests/test_grep.rs
+++ b/tests/test_grep.rs
@@ -675,6 +675,30 @@ fn empty_pattern_matches_every_line() {
 }
 
 #[test]
+fn inverted_empty_pattern_does_not_short_circuit_under_x_or_w() {
+    // Under `-x` the empty pattern matches only an empty line, and under `-w`
+    // only an empty match at a word boundary, so `-v` still selects the rest.
+    let (_s, mut c) = ucmd();
+    c.args(&["-e", "", "-x", "-v"])
+        .pipe_in("abc\ndef\n")
+        .succeeds()
+        .stdout_only("abc\ndef\n");
+
+    let (_s, mut c) = ucmd();
+    c.args(&["-e", "", "-w", "-v"])
+        .pipe_in("abc\ndef\n")
+        .succeeds()
+        .stdout_only("abc\ndef\n");
+
+    // `-x` still drops the empty line itself.
+    let (_s, mut c) = ucmd();
+    c.args(&["-e", "", "-x", "-v"])
+        .pipe_in("abc\n\ndef\n")
+        .succeeds()
+        .stdout_only("abc\ndef\n");
+}
+
+#[test]
 fn inverted_empty_pattern_short_circuits() {
     // grep short-circuits without reading stdin at all, so the harness's write
     // races grep's exit and may fail with EPIPE.


### PR DESCRIPTION
Fixes #65.

The `-v` + empty-pattern fast path returned "no lines selected, exit 1" without reading input, on the assumption that an empty pattern matches every line. Under `-x` the empty pattern matches only an empty line, and under `-w` only an empty match at a word boundary, so the inversion should still select the remaining lines. Gated the short-circuit on neither flag being set.

```
$ printf 'abc\ndef\n' | grep -e '' -x -v
abc
def
```

Diffed against GNU grep across `-x`/`-w` combined with `-v`, `-i`, `-c`, `-n`, `-o` and `-E`. All `-x` cases now agree, including exit codes, and the plain `-v` short-circuit is untouched (its existing test still passes).

**One divergence remains under `-w`, and it is separate from this change.** `uu_grep` treats an empty line as matching `-w` with an empty pattern; GNU does not:

```
$ printf 'abc\n\ndef\n' | grep -e '' -w    # uu: prints the empty line, exit 0
$ printf 'abc\n\ndef\n' | grep -e '' -w    # GNU: no output, exit 1
```

That reproduces on `main` with no `-v` involved, so it is a `-w` matcher issue rather than a short-circuit one — the consequence is that `-w -v` still drops empty lines that GNU keeps. I left it alone to keep this change to what the issue describes; happy to open a separate issue for it, or fold a fix in here if you would rather.

Tests cover `-x`/`-w` on input without empty lines and `-x` on input with one. `cargo test`: 95 passed. clippy `-D warnings` and `cargo fmt --check` clean.