### PR TITLE
grep: honor \s and \S in basic regexps

### DIFF
--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -277,6 +277,11 @@ impl CompiledPattern {
             // GNU grep supports \` and \' as buffer anchors in BRE and ERE.
             syntax.enable_operators(SyntaxOperator::SYNTAX_OPERATOR_ESC_GNU_BUF_ANCHOR);
         }
+        if config.regex_mode == RegexMode::Basic {
+            // GNU grep supports \s and \S as extensions in BRE, like \w and \W.
+            // `Syntax::grep()` leaves them off, so they parse as literal s / S.
+            syntax.enable_operators(SyntaxOperator::SYNTAX_OPERATOR_ESC_S_WHITE_SPACE);
+        }
 
         if matches!(config.regex_mode, RegexMode::Basic | RegexMode::Extended)
             && has_confusing_bracket(pattern.as_bytes())

--- a/tests/test_grep.rs
+++ b/tests/test_grep.rs
@@ -101,6 +101,30 @@ fn gnu_buffer_anchors() {
 }
 
 #[test]
+fn whitespace_escapes_in_basic_regexp() {
+    // GNU grep honors \s and \S in BRE as well as ERE, like \w and \W.
+    let input = "a b\nxy\n";
+
+    for args in [
+        vec![r"\s"],
+        vec!["-G", r"\s"],
+        vec!["-E", r"\s"],
+        vec!["-e", r"\s"],
+    ] {
+        let (_s, mut c) = ucmd();
+        c.args(&args).pipe_in(input).succeeds().stdout_only("a b\n");
+    }
+
+    for args in [vec![r"\S"], vec!["-G", r"\S"], vec!["-E", r"\S"]] {
+        let (_s, mut c) = ucmd();
+        c.args(&args)
+            .pipe_in(input)
+            .succeeds()
+            .stdout_only("a b\nxy\n");
+    }
+}
+
+#[test]
 fn ere_metacharacters() {
     let cases: &[(&[&str], &str, &str)] = &[
         (&["-E", "Hi|HI"], "Hi\nHI\nhi\n", "Hi\nHI\n"),


### PR DESCRIPTION
Fixes #31.

`Syntax::grep()` leaves `ONIG_SYN_OP_ESC_S_WHITE_SPACE` off, so in BRE `\s` and `\S` parsed as the literal letters `s` and `S`. GNU grep supports both as extensions in basic regexps, the same way it does `\w`/`\W` (which oniguruma already enables for `grep` syntax). Enabled the operator for `Basic` mode, alongside the existing GNU buffer-anchor line just above it; `Extended` already gets it from `Syntax::gnu_regex()`.

```
$ printf 'a b\nxy\n' | grep -e '\s'
a b
```

Checked the counts from the issue against GNU grep on input `aS b` / `  ` / `x`, across `\s`, `\S`, `\w`, `\W` in default, `-G` and `-E` modes — all twelve combinations agree, where before `\s` gave 0 and `\S` gave 1 in BRE.

`cargo test`: 95 passed. clippy `-D warnings` and `cargo fmt --check` clean.

### GNU testsuite: net +1, but one new failure worth flagging

```
PASSED: +1   FAILED: -1
  + backslash-s-and-repetition-operators
  + multibyte-white-space
  - backslash-s-vs-invalid-multibyte
```

`backslash-s-vs-invalid-multibyte` checks that neither `\s` nor `\S` matches a lone invalid byte (`\202`) in a UTF-8 locale. It passed before only because `\S` was an inert literal `S` in BRE — the underlying behavior is already wrong in ERE on `main`:

```
$ printf '\202\n' > in
$ ./target/release/grep -E '^\S$' in ; echo $?    # main, unpatched: 0 (should be 1)
```

So this does not introduce the bug, it just stops hiding it in BRE — the same invalid-multibyte / non-ASCII character-class handling tracked in #64. Fixing it belongs there rather than here, since it needs a decision about how invalid bytes are classified generally, not just for `\s`.

Happy to hold this until #64 lands if you would rather not take the one test regression in the interim.