### PR TITLE
grep: support POSIX equivalence classes in brackets

### DIFF
--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -4,7 +4,7 @@
 // file that was distributed with this source code.
 
 use crate::{Config, RegexMode};
-use memchr::memmem;
+use memchr::{memchr, memmem};
 use onig::{RegexOptions, Region, SearchOptions, Syntax, SyntaxBehavior, SyntaxOperator};
 use onig_sys::{
     ONIGERR_EMPTY_RANGE_IN_CHAR_CLASS, OnigEncCtype_ONIGENC_CTYPE_WORD, OnigEncodingUTF8,
@@ -549,20 +549,37 @@ fn strip_leading_interval_repeat(pattern: &str) -> Option<&str> {
 /// class or collating element.
 fn has_confusing_bracket(pattern: &[u8]) -> bool {
     let mut i = 0;
-    while i < pattern.len() {
-        match pattern[i] {
-            b'\\' => i += 2,
-            b'[' => {
-                let (confusing, next) = scan_bracket(pattern, i + 1);
-                if confusing {
-                    return true;
-                }
-                i = next;
-            }
-            _ => i += 1,
+    while let Some(open) = next_unescaped_bracket(pattern, i) {
+        let (confusing, next) = scan_bracket(pattern, open + 1);
+        if confusing {
+            return true;
         }
+        i = next;
     }
     false
+}
+
+/// Index of the first `[` at or after `from` that is not escaped by a
+/// backslash, or `None` if the pattern holds no such bracket.
+///
+/// Only `[` is significant between bracket expressions, so jump straight to
+/// the next one instead of walking the pattern a byte at a time. A backslash
+/// run directly in front of the match decides whether it opens a bracket: an
+/// odd count escapes it, an even one leaves the `[` itself unescaped (`\\[`).
+fn next_unescaped_bracket(pattern: &[u8], from: usize) -> Option<usize> {
+    let mut search = from;
+    while let Some(offset) = memchr(b'[', &pattern[search..]) {
+        let at = search + offset;
+        let mut backslashes = 0;
+        while at - backslashes > from && pattern[at - backslashes - 1] == b'\\' {
+            backslashes += 1;
+        }
+        if backslashes % 2 == 0 {
+            return Some(at);
+        }
+        search = at + 1;
+    }
+    None
 }
 
 /// Scan the body of a bracket expression starting at `start` (just past the
@@ -643,21 +660,15 @@ fn rewrite_equivalence_classes(pattern: &str) -> Cow<'_, str> {
     let mut copied = 0;
     let mut i = 0;
 
-    while i < bytes.len() {
-        match bytes[i] {
-            b'\\' => i += 2,
-            b'[' => {
-                let (rewritten, next) = scan_equivalence_bracket(pattern, i);
-                if let Some(body) = rewritten {
-                    let out = out.get_or_insert_with(String::new);
-                    out.push_str(&pattern[copied..=i]);
-                    out.push_str(&body);
-                    copied = next;
-                }
-                i = next;
-            }
-            _ => i += 1,
+    while let Some(open) = next_unescaped_bracket(bytes, i) {
+        let (rewritten, next) = scan_equivalence_bracket(pattern, open);
+        if let Some(body) = rewritten {
+            let out = out.get_or_insert_with(String::new);
+            out.push_str(&pattern[copied..=open]);
+            out.push_str(&body);
+            copied = next;
         }
+        i = next;
     }
 
     match out {
@@ -837,6 +848,7 @@ mod tests {
             "[:notaclass:]",
             "[:x:]",
             "ab[:blank:]",
+            "\\\\[:blank:]", // the backslash is escaped, so the bracket is not
         ] {
             assert!(has_confusing_bracket(p.as_bytes()), "pattern {p:?}");
         }
@@ -845,18 +857,19 @@ mod tests {
     #[test]
     fn accepts_bracket_expressions_that_are_not_confusing() {
         for p in [
-            "[[:digit:]]",    // the correct spelling
-            "[::]",           // no character besides the colons
-            "[:digit]",       // does not end with a colon
-            "[:digit:qrs]",   // ends with an ordinary character
-            "[:dig-it:]",     // holds a range
-            "[:x[:digit:]:]", // holds a character class
-            "[:x[.,.]:]",     // holds a collating element
-            "[:x[=e=]:]",     // holds an equivalence class
-            "\\[:digit:]",    // the bracket is escaped
-            "[]:digit:]",     // starts with a literal ']'
-            "[:digit:",       // unterminated
-            "[a-z]+[0-9]",    // no colons at all
+            "[[:digit:]]",     // the correct spelling
+            "[::]",            // no character besides the colons
+            "[:digit]",        // does not end with a colon
+            "[:digit:qrs]",    // ends with an ordinary character
+            "[:dig-it:]",      // holds a range
+            "[:x[:digit:]:]",  // holds a character class
+            "[:x[.,.]:]",      // holds a collating element
+            "[:x[=e=]:]",      // holds an equivalence class
+            "\\[:digit:]",     // the bracket is escaped
+            "\\\\\\[:digit:]", // and still escaped after an escaped backslash
+            "[]:digit:]",      // starts with a literal ']'
+            "[:digit:",        // unterminated
+            "[a-z]+[0-9]",     // no colons at all
         ] {
             assert!(!has_confusing_bracket(p.as_bytes()), "pattern {p:?}");
         }

--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -5,6 +5,7 @@
 
 use crate::{Config, RegexMode};
 use memchr::memmem;
+use std::borrow::Cow;
 use onig::{RegexOptions, Region, SearchOptions, Syntax, SyntaxBehavior, SyntaxOperator};
 use onig_sys::{
     ONIGERR_EMPTY_RANGE_IN_CHAR_CLASS, OnigEncCtype_ONIGENC_CTYPE_WORD, OnigEncodingUTF8,
@@ -286,6 +287,13 @@ impl CompiledPattern {
                 "character class syntax is [[:space:]], not [:space:]".to_string(),
             ));
         }
+
+        let pattern = if config.regex_mode == RegexMode::Fixed {
+            Cow::Borrowed(pattern)
+        } else {
+            rewrite_equivalence_classes(pattern)
+        };
+        let pattern: &str = &pattern;
 
         let mut normalized_pattern = None;
         let pattern = if config.regex_mode == RegexMode::Extended {
@@ -608,6 +616,127 @@ fn scan_bracket(pattern: &[u8], start: usize) -> (bool, usize) {
     (false, pattern.len())
 }
 
+/// Rewrite POSIX equivalence classes (`[=c=]`) to their bare member `c`.
+///
+/// A POSIX bracket expression may contain an equivalence class `[=c=]` that
+/// matches every character collating equal to `c`. In the single-byte C locale
+/// that set is just `c` itself, and oniguruma has no syntax for equivalence
+/// classes at all, so a pattern containing one cannot be compiled as-is. This
+/// function rewrites the classes oniguruma cannot express into the nearest
+/// equivalent it can, leaving everything else in the pattern untouched:
+///
+/// * `[[=a=]]` becomes `[a]`        — the class collapses to its sole member.
+/// * `[[=a=]b]` becomes `[ab]`      — members compose with other entries.
+/// * `[[=a=][=b=]]` becomes `[ab]`  — several classes in one bracket.
+/// * `x[[=a=]]y` becomes `x[a]y`    — text outside the bracket is preserved.
+///
+/// Returns a borrowed `Cow` when there is nothing to rewrite (the common case,
+/// so no allocation is needed) and an owned one otherwise.
+///
+/// A class whose body is not exactly one character is left in place, as is one
+/// used as a range endpoint (an error in GNU grep, so it must not be quietly
+/// turned into a range) or one holding `]`, `^`, `-` or `\`, whose meaning
+/// inside a bracket expression depends on where it sits.
+fn rewrite_equivalence_classes(pattern: &str) -> Cow<'_, str> {
+    let bytes = pattern.as_bytes();
+    let mut out: Option<String> = None;
+    let mut copied = 0;
+    let mut i = 0;
+
+    while i < bytes.len() {
+        match bytes[i] {
+            b'\\' => i += 2,
+            b'[' => {
+                let (rewritten, next) = scan_equivalence_bracket(pattern, i);
+                if let Some(body) = rewritten {
+                    let out = out.get_or_insert_with(String::new);
+                    out.push_str(&pattern[copied..=i]);
+                    out.push_str(&body);
+                    copied = next;
+                }
+                i = next;
+            }
+            _ => i += 1,
+        }
+    }
+
+    match out {
+        None => Cow::Borrowed(pattern),
+        Some(mut s) => {
+            s.push_str(&pattern[copied..]);
+            Cow::Owned(s)
+        }
+    }
+}
+
+/// Scan a single bracket expression whose opening `[` is at `open` and rewrite
+/// every rewritable `[=c=]` equivalence class in its body to the bare member
+/// `c`. Returns the rewritten body (including the closing `]`) together with
+/// the index just past that `]`; the body is `None` when the bracket contains
+/// no rewritable equivalence class, so the caller can leave the span alone.
+/// Mirrors `scan_bracket`, which does the equivalent job for
+/// `has_confusing_bracket`, so the two stay structurally identical.
+fn scan_equivalence_bracket(pattern: &str, open: usize) -> (Option<String>, usize) {
+    let bytes = pattern.as_bytes();
+    let mut j = open + 1;
+    if bytes.get(j) == Some(&b'^') {
+        j += 1;
+    }
+    let body_start = j;
+    let mut out: Option<String> = None;
+    let mut copied = open + 1;
+
+    while j < bytes.len() {
+        // A `]` at the very start of the body is an ordinary character; any
+        // other `]` closes the bracket.
+        if bytes[j] == b']' && j != body_start {
+            if let Some(out) = out.as_mut() {
+                out.push_str(&pattern[copied..=j]);
+            }
+            return (out, j + 1);
+        }
+        // `[:`, `[.` and `[=` subexpressions inside the bracket.
+        if bytes[j] == b'[' && matches!(bytes.get(j + 1), Some(b':' | b'.' | b'=')) {
+            let delimiter = bytes[j + 1];
+            if let Some(end) = find_bracket_subexpr_end(bytes, j + 2, delimiter) {
+                if delimiter == b'='
+                    && is_rewritable_equivalence(
+                        &pattern[j + 2..end - 2],
+                        bytes.get(end).copied(),
+                        if j > 0 { Some(bytes[j - 1]) } else { None },
+                    )
+                {
+                    let body = &pattern[j + 2..end - 2];
+                    let out = out.get_or_insert_with(String::new);
+                    out.push_str(&pattern[copied..j]);
+                    out.push_str(body);
+                    copied = end;
+                }
+                j = end;
+                continue;
+            }
+        }
+        j += 1;
+    }
+    // Unterminated bracket: leave it for the regex engine to report, but still
+    // flush whatever rewrite was already written into `out`.
+    if let Some(out) = out.as_mut() {
+        out.push_str(&pattern[copied..]);
+    }
+    (out, pattern.len())
+}
+
+/// True when a `[=...=]` equivalence class whose body is `body` can be replaced
+/// by that single character. GNU grep rejects equivalence classes used as range
+/// endpoints, so a class directly preceded or followed by `-` (`prev`/`next`)
+/// is left in place rather than silently producing a range.
+fn is_rewritable_equivalence(body: &str, next: Option<u8>, prev: Option<u8>) -> bool {
+    let in_range = next == Some(b'-') || prev == Some(b'-');
+    body.chars().count() == 1
+        && !body.starts_with([']', '^', '-', '\\'])
+        && !in_range
+}
+
 /// Index just past the `:]`, `.]` or `=]` closing a `[: [. [=` subexpression
 /// whose body starts at `start`.
 fn find_bracket_subexpr_end(pattern: &[u8], start: usize, delimiter: u8) -> Option<usize> {
@@ -618,8 +747,48 @@ fn find_bracket_subexpr_end(pattern: &[u8], start: usize, delimiter: u8) -> Opti
 
 #[cfg(test)]
 mod tests {
-    use super::{has_confusing_bracket, plain_literal};
+    use super::{has_confusing_bracket, plain_literal, rewrite_equivalence_classes};
     use crate::RegexMode;
+    use std::borrow::Cow;
+
+    fn r(p: &str) -> Cow<'_, str> {
+        rewrite_equivalence_classes(p)
+    }
+
+    #[test]
+    fn equivalence_classes_reduce_to_their_member() {
+        // Rewrites allocate an owned string.
+        assert_eq!(&*r("[[=a=]]"), "[a]");
+        assert_eq!(&*r("[[=a=]b]"), "[ab]");
+        assert_eq!(&*r("[b[=a=]]"), "[ba]");
+        assert_eq!(&*r("[[=a=][=b=]]"), "[ab]");
+        assert_eq!(&*r("[^[=a=]]"), "[^a]");
+        assert_eq!(&*r("x[[=a=]]y"), "x[a]y");
+        assert_eq!(&*r("[[:alpha:][=a=]]"), "[[:alpha:]a]");
+        // The common case borrows the input unchanged: no allocation.
+        assert!(matches!(r("abc"), Cow::Borrowed("abc")));
+    }
+
+    #[test]
+    fn equivalence_class_rewrite_leaves_other_patterns_alone() {
+        // Nothing to do.
+        assert!(matches!(r("abc"), Cow::Borrowed(_)));
+        assert!(matches!(r("[abc]"), Cow::Borrowed(_)));
+        assert!(matches!(r("[[:alpha:]]"), Cow::Borrowed(_)));
+        assert!(matches!(r("[[.a.]]"), Cow::Borrowed(_)));
+        // Not a bracket expression: `[=a=]` outside `[...]` is literal in GNU.
+        assert!(matches!(r("\\[[=a=]"), Cow::Borrowed(_)));
+        // A range endpoint is an error in GNU; don't invent a valid range.
+        assert!(matches!(r("[[=a=]-c]"), Cow::Borrowed(_)));
+        assert!(matches!(r("[a-[=c=]]"), Cow::Borrowed(_)));
+        // Only single-character classes have an obvious C-locale member.
+        assert!(matches!(r("[[=ab=]]"), Cow::Borrowed(_)));
+        assert!(matches!(r("[[==]]"), Cow::Borrowed(_)));
+        // Members whose meaning depends on position inside the bracket.
+        assert!(matches!(r("[[=]=]]"), Cow::Borrowed(_)));
+        assert!(matches!(r("[[=^=]]"), Cow::Borrowed(_)));
+        assert!(matches!(r("[[=-=]]"), Cow::Borrowed(_)));
+    }
 
     fn lit(p: &str, ic: bool, mode: RegexMode) -> Option<Vec<u8>> {
         plain_literal(p, ic, mode)

--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -733,7 +733,11 @@ fn scan_equivalence_bracket(pattern: &str, open: usize) -> (Cow<'_, str>, usize)
             // member is left untouched. `prev` is the byte before the `[`, which
             // is what decides whether the class sits at a range endpoint.
             if bytes.get(j + 1) == Some(&b'=')
-                && is_rewritable_equivalence(&pattern[j + 2..end - 2], bytes.get(end).copied(), prev)
+                && is_rewritable_equivalence(
+                    &pattern[j + 2..end - 2],
+                    bytes.get(end).copied(),
+                    prev,
+                )
             {
                 out.push_str(&pattern[copied..j]);
                 out.push_str(&pattern[j + 2..end - 2]);

--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -697,57 +697,61 @@ fn rewrite_equivalence_classes(pattern: &str) -> Cow<'_, str> {
 /// `has_confusing_bracket`, so the two stay structurally alike.
 fn scan_equivalence_bracket(pattern: &str, open: usize) -> (Cow<'_, str>, usize) {
     let bytes = pattern.as_bytes();
+    // The body starts just past `[`. A leading `^` negates the bracket and a
+    // `]` right after it (or after the `^`) is an ordinary member, so neither
+    // can close the bracket; skip both before the scan begins.
     let mut j = open + 1;
     if bytes.get(j) == Some(&b'^') {
         j += 1;
     }
-    // A `]` at the very start of the body is an ordinary character; any later
-    // unescaped `]` closes the bracket.
     let body_start = j;
     if bytes.get(j) == Some(&b']') {
         j += 1;
     }
 
     let mut out = String::new();
-    let mut copied = open + 1;
+    let mut copied = open + 1; // first body byte not yet written into `out`
+    let mut prev: Option<u8> = None; // the byte before `j`, for range-endpoint checks
     let mut escape = false;
 
-    while j < bytes.len() {
-        let c = bytes[j];
+    while let Some(&c) = bytes.get(j) {
+        // An unescaped `]` that is not the leading literal one closes the bracket.
         if !escape && c == b']' && j != body_start {
-            if !out.is_empty() {
-                out.push_str(&pattern[copied..=j]);
-                return (Cow::Owned(out), j + 1);
+            if out.is_empty() {
+                return (Cow::Borrowed(&pattern[open + 1..=j]), j + 1);
             }
-            return (Cow::Borrowed(&pattern[open + 1..=j]), j + 1);
+            out.push_str(&pattern[copied..=j]);
+            return (Cow::Owned(out), j + 1);
         }
-        // A `[:`, `[.` or `[=` subexpression inside the bracket. A preceding
-        // backslash escapes the `[`, so it is a literal, not a subexpr start.
+        // An unescaped `[` may open a `[:...]`, `[...]` or `[=...]` member. A
+        // preceding backslash escapes it, so it is a literal, not a member start.
         if !escape
             && c == b'['
             && let Some(end) = bracket_subexpr_end(bytes, j)
         {
-            if bytes[j + 1] == b'='
-                && is_rewritable_equivalence(
-                    &pattern[j + 2..end - 2],
-                    bytes.get(end).copied(),
-                    bytes.get(j.wrapping_sub(1)).copied(),
-                )
+            // A rewritable `[=c=]` collapses to its sole member `c`; any other
+            // member is left untouched. `prev` is the byte before the `[`, which
+            // is what decides whether the class sits at a range endpoint.
+            if bytes.get(j + 1) == Some(&b'=')
+                && is_rewritable_equivalence(&pattern[j + 2..end - 2], bytes.get(end).copied(), prev)
             {
                 out.push_str(&pattern[copied..j]);
                 out.push_str(&pattern[j + 2..end - 2]);
                 copied = end;
             }
+            // A member always ends in `]`, so the next byte cannot be mid-range.
+            prev = Some(b']');
             j = end;
             escape = false;
             continue;
         }
         escape = c == b'\\' && !escape;
+        prev = Some(c);
         j += 1;
     }
 
-    // Unterminated bracket: leave it for the regex engine to report, but flush
-    // whatever rewrite was already written into `out`.
+    // Unterminated bracket: let the regex engine report it. Flush any rewrite
+    // already started; otherwise lend the body back unchanged.
     if out.is_empty() {
         (Cow::Borrowed(&pattern[open + 1..]), bytes.len())
     } else {

--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -656,14 +656,13 @@ fn scan_bracket(pattern: &[u8], start: usize) -> (bool, usize) {
 /// inside a bracket expression depends on where it sits.
 fn rewrite_equivalence_classes(pattern: &str) -> Cow<'_, str> {
     let bytes = pattern.as_bytes();
-    let mut out: Option<String> = None;
+    let mut out = String::new();
     let mut copied = 0;
     let mut i = 0;
 
     while let Some(open) = next_unescaped_bracket(bytes, i) {
         let (rewritten, next) = scan_equivalence_bracket(pattern, open);
         if let Some(body) = rewritten {
-            let out = out.get_or_insert_with(String::new);
             out.push_str(&pattern[copied..=open]);
             out.push_str(&body);
             copied = next;
@@ -671,12 +670,11 @@ fn rewrite_equivalence_classes(pattern: &str) -> Cow<'_, str> {
         i = next;
     }
 
-    match out {
-        None => Cow::Borrowed(pattern),
-        Some(mut s) => {
-            s.push_str(&pattern[copied..]);
-            Cow::Owned(s)
-        }
+    if out.is_empty() {
+        Cow::Borrowed(pattern)
+    } else {
+        out.push_str(&pattern[copied..]);
+        Cow::Owned(out)
     }
 }
 

--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -5,11 +5,11 @@
 
 use crate::{Config, RegexMode};
 use memchr::memmem;
-use std::borrow::Cow;
 use onig::{RegexOptions, Region, SearchOptions, Syntax, SyntaxBehavior, SyntaxOperator};
 use onig_sys::{
     ONIGERR_EMPTY_RANGE_IN_CHAR_CLASS, OnigEncCtype_ONIGENC_CTYPE_WORD, OnigEncodingUTF8,
 };
+use std::borrow::Cow;
 use std::ptr::{null, null_mut};
 use std::sync::Mutex;
 use uucore::error::{UResult, USimpleError};
@@ -732,9 +732,7 @@ fn scan_equivalence_bracket(pattern: &str, open: usize) -> (Option<String>, usiz
 /// is left in place rather than silently producing a range.
 fn is_rewritable_equivalence(body: &str, next: Option<u8>, prev: Option<u8>) -> bool {
     let in_range = next == Some(b'-') || prev == Some(b'-');
-    body.chars().count() == 1
-        && !body.starts_with([']', '^', '-', '\\'])
-        && !in_range
+    body.chars().count() == 1 && !body.starts_with([']', '^', '-', '\\']) && !in_range
 }
 
 /// Index just past the `:]`, `.]` or `=]` closing a `[: [. [=` subexpression

--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -4,7 +4,7 @@
 // file that was distributed with this source code.
 
 use crate::{Config, RegexMode};
-use memchr::{memchr, memmem};
+use memchr::memmem;
 use onig::{RegexOptions, Region, SearchOptions, Syntax, SyntaxBehavior, SyntaxOperator};
 use onig_sys::{
     ONIGERR_EMPTY_RANGE_IN_CHAR_CLASS, OnigEncCtype_ONIGENC_CTYPE_WORD, OnigEncodingUTF8,
@@ -549,7 +549,7 @@ fn strip_leading_interval_repeat(pattern: &str) -> Option<&str> {
 /// class or collating element.
 fn has_confusing_bracket(pattern: &[u8]) -> bool {
     let mut i = 0;
-    while let Some(open) = next_unescaped_bracket(pattern, i) {
+    while let Some(open) = next_unescaped(pattern, i, b'[') {
         let (confusing, next) = scan_bracket(pattern, open + 1);
         if confusing {
             return true;
@@ -559,25 +559,29 @@ fn has_confusing_bracket(pattern: &[u8]) -> bool {
     false
 }
 
-/// Index of the first `[` at or after `from` that is not escaped by a
-/// backslash, or `None` if the pattern holds no such bracket.
+/// Index of the first `needle` at or after `from` that is not escaped by a
+/// backslash, or `None` if the pattern holds no such byte.
 ///
-/// Only `[` is significant between bracket expressions, so jump straight to
-/// the next one instead of walking the pattern a byte at a time. A backslash
-/// run directly in front of the match decides whether it opens a bracket: an
-/// odd count escapes it, an even one leaves the `[` itself unescaped (`\\[`).
-fn next_unescaped_bracket(pattern: &[u8], from: usize) -> Option<usize> {
-    let mut search = from;
-    while let Some(offset) = memchr(b'[', &pattern[search..]) {
-        let at = search + offset;
-        let mut backslashes = 0;
-        while at - backslashes > from && pattern[at - backslashes - 1] == b'\\' {
-            backslashes += 1;
+/// Tracking the backslash run as we walk (rather than looking back from each
+/// hit) keeps the scan linear, and one helper serves every "next significant
+/// byte" search in a pattern: the opening `[` of a bracket expression, the
+/// closing `]`, and the `:`/`.`/`=` that ends a `[:`/`[.`/`[=` subexpression.
+/// An odd run of backslashes in front of a byte escapes it; an even one leaves
+/// it literal (so `\\[` is an unescaped `[`).
+fn next_unescaped(pattern: &[u8], mut from: usize, needle: u8) -> Option<usize> {
+    let mut escape = false;
+    while from < pattern.len() {
+        match pattern[from] {
+            b'\\' => escape = !escape,
+            c if c == needle => {
+                if !escape {
+                    return Some(from);
+                }
+                escape = false;
+            }
+            _ => escape = false,
         }
-        if backslashes % 2 == 0 {
-            return Some(at);
-        }
-        search = at + 1;
+        from += 1;
     }
     None
 }
@@ -610,13 +614,12 @@ fn scan_bracket(pattern: &[u8], start: usize) -> (bool, usize) {
         // Only the character just before the closing `]` counts as the last one.
         state &= !LAST_IS_COLON;
         // `[:alpha:]`, `[.a.]` and `[=a=]` inside the bracket.
-        if c == b'[' && matches!(pattern.get(i + 1), Some(b':' | b'.' | b'=')) {
-            let delimiter = pattern[i + 1];
-            if let Some(end) = find_bracket_subexpr_end(pattern, i + 2, delimiter) {
-                state |= HAS_RANGE_OR_CLASS;
-                i = end;
-                continue;
-            }
+        if c == b'['
+            && let Some(end) = bracket_subexpr_end(pattern, i)
+        {
+            state |= HAS_RANGE_OR_CLASS;
+            i = end;
+            continue;
         }
         // `x-y` is a range, but the `-` of `[x-]` is an ordinary character.
         if pattern.get(i + 1) == Some(&b'-')
@@ -660,9 +663,9 @@ fn rewrite_equivalence_classes(pattern: &str) -> Cow<'_, str> {
     let mut copied = 0;
     let mut i = 0;
 
-    while let Some(open) = next_unescaped_bracket(bytes, i) {
-        let (rewritten, next) = scan_equivalence_bracket(pattern, open);
-        if let Some(body) = rewritten {
+    while let Some(open) = next_unescaped(bytes, i, b'[') {
+        let (body, next) = scan_equivalence_bracket(pattern, open);
+        if let Cow::Owned(body) = body {
             out.push_str(&pattern[copied..=open]);
             out.push_str(&body);
             copied = next;
@@ -680,59 +683,77 @@ fn rewrite_equivalence_classes(pattern: &str) -> Cow<'_, str> {
 
 /// Scan a single bracket expression whose opening `[` is at `open` and rewrite
 /// every rewritable `[=c=]` equivalence class in its body to the bare member
-/// `c`. Returns the rewritten body (including the closing `]`) together with
-/// the index just past that `]`; the body is `None` when the bracket contains
-/// no rewritable equivalence class, so the caller can leave the span alone.
+/// `c`.
+///
+/// Returns the body — from just past the `[` through the closing `]` —
+/// together with the index just past that `]`. The body is borrowed when the
+/// bracket holds no rewritable class (the caller can leave the span untouched
+/// and skip the allocation) and owned once at least one class was collapsed:
+///
+/// * `[[=a=]]`  scans to the borrowed span `=a=]`, then rewrites it to `a]`.
+/// * `[[=a=]b]` keeps the trailing `b]` and rewrites to `ab]`.
+///
 /// Mirrors `scan_bracket`, which does the equivalent job for
-/// `has_confusing_bracket`, so the two stay structurally identical.
-fn scan_equivalence_bracket(pattern: &str, open: usize) -> (Option<String>, usize) {
+/// `has_confusing_bracket`, so the two stay structurally alike.
+fn scan_equivalence_bracket(pattern: &str, open: usize) -> (Cow<'_, str>, usize) {
     let bytes = pattern.as_bytes();
     let mut j = open + 1;
     if bytes.get(j) == Some(&b'^') {
         j += 1;
     }
+    // A `]` at the very start of the body is an ordinary character; any later
+    // unescaped `]` closes the bracket.
     let body_start = j;
-    let mut out: Option<String> = None;
-    let mut copied = open + 1;
-
-    while j < bytes.len() {
-        // A `]` at the very start of the body is an ordinary character; any
-        // other `]` closes the bracket.
-        if bytes[j] == b']' && j != body_start {
-            if let Some(out) = out.as_mut() {
-                out.push_str(&pattern[copied..=j]);
-            }
-            return (out, j + 1);
-        }
-        // `[:`, `[.` and `[=` subexpressions inside the bracket.
-        if bytes[j] == b'[' && matches!(bytes.get(j + 1), Some(b':' | b'.' | b'=')) {
-            let delimiter = bytes[j + 1];
-            if let Some(end) = find_bracket_subexpr_end(bytes, j + 2, delimiter) {
-                if delimiter == b'='
-                    && is_rewritable_equivalence(
-                        &pattern[j + 2..end - 2],
-                        bytes.get(end).copied(),
-                        if j > 0 { Some(bytes[j - 1]) } else { None },
-                    )
-                {
-                    let body = &pattern[j + 2..end - 2];
-                    let out = out.get_or_insert_with(String::new);
-                    out.push_str(&pattern[copied..j]);
-                    out.push_str(body);
-                    copied = end;
-                }
-                j = end;
-                continue;
-            }
-        }
+    if bytes.get(j) == Some(&b']') {
         j += 1;
     }
-    // Unterminated bracket: leave it for the regex engine to report, but still
-    // flush whatever rewrite was already written into `out`.
-    if let Some(out) = out.as_mut() {
-        out.push_str(&pattern[copied..]);
+
+    let mut out = String::new();
+    let mut copied = open + 1;
+    let mut escape = false;
+
+    while j < bytes.len() {
+        let c = bytes[j];
+        if !escape && c == b']' && j != body_start {
+            if !out.is_empty() {
+                out.push_str(&pattern[copied..=j]);
+                return (Cow::Owned(out), j + 1);
+            }
+            return (Cow::Borrowed(&pattern[open + 1..=j]), j + 1);
+        }
+        // A `[:`, `[.` or `[=` subexpression inside the bracket. A preceding
+        // backslash escapes the `[`, so it is a literal, not a subexpr start.
+        if !escape
+            && c == b'['
+            && let Some(end) = bracket_subexpr_end(bytes, j)
+        {
+            if bytes[j + 1] == b'='
+                && is_rewritable_equivalence(
+                    &pattern[j + 2..end - 2],
+                    bytes.get(end).copied(),
+                    bytes.get(j.wrapping_sub(1)).copied(),
+                )
+            {
+                out.push_str(&pattern[copied..j]);
+                out.push_str(&pattern[j + 2..end - 2]);
+                copied = end;
+            }
+            j = end;
+            escape = false;
+            continue;
+        }
+        escape = c == b'\\' && !escape;
+        j += 1;
     }
-    (out, pattern.len())
+
+    // Unterminated bracket: leave it for the regex engine to report, but flush
+    // whatever rewrite was already written into `out`.
+    if out.is_empty() {
+        (Cow::Borrowed(&pattern[open + 1..]), bytes.len())
+    } else {
+        out.push_str(&pattern[copied..]);
+        (Cow::Owned(out), bytes.len())
+    }
 }
 
 /// True when a `[=...=]` equivalence class whose body is `body` can be replaced
@@ -744,12 +765,24 @@ fn is_rewritable_equivalence(body: &str, next: Option<u8>, prev: Option<u8>) -> 
     body.chars().count() == 1 && !body.starts_with([']', '^', '-', '\\']) && !in_range
 }
 
-/// Index just past the `:]`, `.]` or `=]` closing a `[: [. [=` subexpression
-/// whose body starts at `start`.
-fn find_bracket_subexpr_end(pattern: &[u8], start: usize, delimiter: u8) -> Option<usize> {
-    (start..pattern.len().saturating_sub(1))
-        .find(|&i| pattern[i] == delimiter && pattern[i + 1] == b']')
-        .map(|i| i + 2)
+/// If a `[:`, `[.` or `[=` subexpression starts at `start` (the `[`), return the
+/// index just past its closing `:]`/`.]`/`=]`. The closing delimiter must not be
+/// escaped, so a `\:` (or `\.`/`\=`) in the body does not end the subexpression.
+/// Both `scan_bracket` and `scan_equivalence_bracket` share this helper so the
+/// two stay consistent.
+fn bracket_subexpr_end(pattern: &[u8], start: usize) -> Option<usize> {
+    let delimiter = *pattern.get(start + 1)?;
+    if !matches!(delimiter, b':' | b'.' | b'=') {
+        return None;
+    }
+    let mut from = start + 2;
+    loop {
+        let at = next_unescaped(pattern, from, delimiter)?;
+        if pattern.get(at + 1) == Some(&b']') {
+            return Some(at + 2);
+        }
+        from = at + 1;
+    }
 }
 
 #[cfg(test)]

--- a/tests/test_grep.rs
+++ b/tests/test_grep.rs
@@ -101,6 +101,44 @@ fn gnu_buffer_anchors() {
 }
 
 #[test]
+fn posix_equivalence_classes() {
+    // In the C locale `[[=a=]]` is equivalent to `[a]`.
+    let input = "a\nb\nc\n";
+
+    for args in [vec!["[[=a=]]"], vec!["-E", "[[=a=]]"], vec!["a[[=a=]]*"]] {
+        let (_s, mut c) = ucmd();
+        c.args(&args).pipe_in(input).succeeds().stdout_only("a\n");
+    }
+
+    // The class must not poison the rest of the bracket expression.
+    for args in [
+        vec!["[[=a=]b]"],
+        vec!["[b[=a=]]"],
+        vec!["[[=a=][=b=]]"],
+        vec!["-E", "[[=a=]b]"],
+    ] {
+        let (_s, mut c) = ucmd();
+        c.args(&args)
+            .pipe_in(input)
+            .succeeds()
+            .stdout_only("a\nb\n");
+    }
+
+    let (_s, mut c) = ucmd();
+    c.args(&["[^[=a=]]"])
+        .pipe_in(input)
+        .succeeds()
+        .stdout_only("b\nc\n");
+
+    // `-F` takes the whole thing literally.
+    let (_s, mut c) = ucmd();
+    c.args(&["-F", "[[=a=]]"])
+        .pipe_in("[[=a=]]\na\n")
+        .succeeds()
+        .stdout_only("[[=a=]]\n");
+}
+
+#[test]
 fn ere_metacharacters() {
     let cases: &[(&[&str], &str, &str)] = &[
         (&["-E", "Hi|HI"], "Hi\nHI\nhi\n", "Hi\nHI\n"),


### PR DESCRIPTION
Fixes #35.

Oniguruma has no syntax for POSIX equivalence classes, so `[[=a=]]` matched nothing and, worse, poisoned the surrounding bracket expression — `[[=a=]b]` stopped matching `b` too.

In the C locale an equivalence class holds only the character itself, so this rewrites `[=c=]` to a bare `c` inside bracket expressions before compiling. The walk reuses the existing `find_bracket_subexpr_end` helper and skips `[:class:]` / `[.symbol.]` so they are untouched.

Three cases are deliberately left unrewritten, since a naive substitution would be wrong rather than merely unsupported:

- **Range endpoints** (`[[=a=]-c]`). GNU rejects these as `invalid character range`; rewriting would silently produce a valid `[a-c]`. Left alone, so behavior is unchanged from `main`.
- **Multi-character or empty bodies** (`[[=ab=]]`, `[[==]]`). GNU reports `invalid collating element`.
- **Members whose meaning is positional inside a bracket** — `]`, `^`, `-`, `\`.

Those still differ from GNU in that we do not *report* the error (exit 1, no diagnostic, exactly as on `main`) — that is a pre-existing gap in bracket error reporting, not something this changes.

Diffed 14 pattern shapes against GNU grep: the 11 matching-behavior cases now agree, and the 3 that remain are the error-reporting ones above, each returning main's existing exit 1.

Tests: unit tests for the rewrite itself, plus integration coverage for the class alone, combined with other bracket members, negated, under `-E`, and taken literally under `-F`. `cargo test`: 95 integration + 15 unit passed. clippy `-D warnings` and `cargo fmt --check` clean.